### PR TITLE
Unify window insets and scaffold padding across UI screens for consistent edge-to-edge support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity
             android:name=".MainActivity"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/splashScreenTheme">

--- a/app/src/main/java/com/music/spotui/App.kt
+++ b/app/src/main/java/com/music/spotui/App.kt
@@ -43,9 +43,7 @@ fun App() {
     }
 
     Scaffold(
-        modifier = Modifier
-            .navigationBarsPadding()
-        ,
+        modifier = Modifier,
         bottomBar = {
             MainBottomNavigation(navController = navController, bottomBarState = bottomBarState, bottomBarPlayerState)
         }

--- a/app/src/main/java/com/music/spotui/MainActivity.kt
+++ b/app/src/main/java/com/music/spotui/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
@@ -50,13 +51,10 @@ class MainActivity : ComponentActivity() {
         controllerFuture = MediaController.Builder(this, token).buildAsync()
 
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = android.graphics.Color.TRANSPARENT
-
-        val controller = WindowInsetsControllerCompat(window, window.decorView)
-        controller.isAppearanceLightStatusBars = false
-
-//        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
+        enableEdgeToEdge()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
         setContent {
 
             SpotuiTheme {

--- a/app/src/main/java/com/music/spotui/ui/components/LikedSongsAlbum.kt
+++ b/app/src/main/java/com/music/spotui/ui/components/LikedSongsAlbum.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -63,7 +64,6 @@ import com.music.spotui.ui.theme.AppBackground
 import com.music.spotui.ui.theme.AppPalette
 import com.music.spotui.ui.viewmodel.AlbumViewModel
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class)
 @Composable
 fun LikedSongsScreen(
@@ -92,6 +92,7 @@ fun LikedSongsScreen(
 
 
     Scaffold(
+        containerColor = Color.Transparent,
         topBar = {
             CenterAlignedTopAppBar(
                 modifier = Modifier.padding(16.dp, 0.dp),
@@ -116,12 +117,14 @@ fun LikedSongsScreen(
                 }
             )
         }
-    ){
+    ) { innerPadding ->
 
 
         Column(modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))
+            .consumeWindowInsets(innerPadding)
+            .padding(bottom = innerPadding.calculateBottomPadding())
             .verticalScroll(rememberScrollState())
         ) {
 

--- a/app/src/main/java/com/music/spotui/ui/components/SavedInSheet.kt
+++ b/app/src/main/java/com/music/spotui/ui/components/SavedInSheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -104,7 +105,7 @@ fun SavedInSheet(
         sheetState = sheetState,
         containerColor = Color(0xFF1A1A1A),
     ) {
-        Column(modifier = Modifier.navigationBarsPadding()) {
+        Column(modifier = Modifier.navigationBarsPadding().imePadding()) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/music/spotui/ui/navigation/MainBottomNavigation.kt
+++ b/app/src/main/java/com/music/spotui/ui/navigation/MainBottomNavigation.kt
@@ -33,6 +33,8 @@ import com.music.spotui.ui.components.MiniPlayer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
+import androidx.compose.foundation.layout.navigationBarsPadding
+
 class NoRippleInteractionSource : MutableInteractionSource {
 
     override val interactions: Flow<Interaction> = emptyFlow()
@@ -59,7 +61,6 @@ fun MainBottomNavigation(navController: NavHostController, bottomBarState: Mutab
                 contentAlignment = Alignment.BottomCenter,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(130.dp)
                     .background(
                         Brush.verticalGradient(
                             colors = listOf(
@@ -71,7 +72,7 @@ fun MainBottomNavigation(navController: NavHostController, bottomBarState: Mutab
                     )
             ) {
 
-                Column {
+                Column(modifier = Modifier.navigationBarsPadding()) {
 
                     AnimatedVisibility(
                         visible = bottomBarPlayerState.value,

--- a/app/src/main/java/com/music/spotui/ui/screens/AlbumScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/AlbumScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -127,7 +128,6 @@ fun AlbumScreen(navController: NavController, albumName: String, artist: String 
     }
 
 }
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun SumUpAlbumScreen(
@@ -195,6 +195,7 @@ fun SumUpAlbumScreen(
 
     Log.d("color", dominentColor.toString())
     Scaffold(
+        containerColor = Color.Transparent,
         topBar = {
             CenterAlignedTopAppBar(
                 modifier = Modifier.padding(16.dp, 0.dp),
@@ -219,12 +220,14 @@ fun SumUpAlbumScreen(
                 }
             )
         }
-    ){
+    ) { innerPadding ->
 
 
         Column(modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))
+            .consumeWindowInsets(innerPadding)
+            .padding(bottom = innerPadding.calculateBottomPadding())
             .verticalScroll(rememberScrollState())
         ) {
 

--- a/app/src/main/java/com/music/spotui/ui/screens/ArtistScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/ArtistScreen.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -138,6 +140,7 @@ private fun ArtistOverviewContent(
     }
 
     LazyColumn(
+        contentPadding = PaddingValues(bottom = 130.dp),
         modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))
@@ -173,7 +176,8 @@ private fun ArtistOverviewContent(
                     contentDescription = "",
                     tint = Color.White,
                     modifier = Modifier
-                        .padding(16.dp, 40.dp)
+                        .statusBarsPadding()
+                        .padding(16.dp, 12.dp)
                         .size(26.dp)
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
@@ -404,8 +408,6 @@ private fun ArtistOverviewContent(
                 }
             }
         }
-
-        item { Spacer(Modifier.height(120.dp)) }
     }
 }
 
@@ -608,6 +610,7 @@ fun ArtistReleasesScreen(navController: NavController, artistName: String) {
         }
 
         LazyColumn(
+            contentPadding = PaddingValues(bottom = 130.dp),
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color(AppBackground.toArgb()))
@@ -617,7 +620,8 @@ fun ArtistReleasesScreen(navController: NavController, artistName: String) {
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp, 40.dp, 16.dp, 12.dp),
+                        .statusBarsPadding()
+                        .padding(16.dp, 12.dp, 16.dp, 12.dp),
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -684,7 +688,6 @@ fun ArtistReleasesScreen(navController: NavController, artistName: String) {
                     }
                 }
             }
-            item { Spacer(Modifier.height(120.dp)) }
         }
     }
 }

--- a/app/src/main/java/com/music/spotui/ui/screens/DownloadsScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/DownloadsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -61,7 +62,6 @@ import com.music.spotui.ui.theme.AppBackground
 import com.music.spotui.ui.theme.AppPalette
 import com.music.spotui.ui.viewmodel.PlayerViewModel
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun DownloadsScreen(navController: NavController) {
@@ -77,16 +77,16 @@ fun DownloadsScreen(navController: NavController) {
         mutableStateOf(com.music.spotui.di.SongPlayer.downloadingSnapshot())
     }
     androidx.compose.runtime.LaunchedEffect(Unit) {
+    LaunchedEffect(Unit) {
         while (true) {
             val snap = com.music.spotui.di.SongPlayer.downloadingSnapshot()
-            // A download leaving the snapshot means it finished → refresh the saved list.
             if (snap.size != inProgress.size) songs = getDownloadedSongs(context)
             inProgress = snap
             kotlinx.coroutines.delay(400)
         }
     }
 
-    var menuSong by remember { mutableStateOf<com.music.spotui.data.entity.SongsModel?>(null) }
+    var menuSong by remember { mutableStateOf<SongsModel?>(null) }
     menuSong?.let { sel ->
         com.music.spotui.ui.components.SongOptionsSheet(
             song = sel,
@@ -96,14 +96,13 @@ fun DownloadsScreen(navController: NavController) {
         )
     }
 
-    val accent = Color(0xFF1DB954)
-
     Surface(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))
     ) {
         Scaffold(
+            containerColor = Color.Transparent,
             topBar = {
                 CenterAlignedTopAppBar(
                     modifier = Modifier.padding(16.dp, 0.dp),
@@ -125,11 +124,13 @@ fun DownloadsScreen(navController: NavController) {
                     title = { Text(text = "") }
                 )
             }
-        ) {
+        ) { innerPadding ->
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color(AppBackground.toArgb()))
+                    .consumeWindowInsets(innerPadding)
+                    .padding(bottom = innerPadding.calculateBottomPadding())
                     .verticalScroll(rememberScrollState())
             ) {
                 Column(

--- a/app/src/main/java/com/music/spotui/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/HistoryScreen.kt
@@ -77,6 +77,7 @@ fun HistoryScreen(navController: NavController) {
 
     Surface(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 130.dp),
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color(AppBackground.toArgb()))

--- a/app/src/main/java/com/music/spotui/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/HomeScreen.kt
@@ -150,6 +150,7 @@ fun HomeFeedContent(navController: NavController, feed: HomeFeedModel) {
     val carousels = if (gridSection != null) sections.drop(1) else sections
 
     LazyColumn(
+        contentPadding = PaddingValues(bottom = 130.dp),
         modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))
@@ -165,7 +166,6 @@ fun HomeFeedContent(navController: NavController, feed: HomeFeedModel) {
         items(carousels.size) { i ->
             HomeFeedSection(navController, carousels[i])
         }
-        item { Spacer(modifier = Modifier.height(120.dp)) }
     }
 }
 

--- a/app/src/main/java/com/music/spotui/ui/screens/LibraryScreeen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/LibraryScreeen.kt
@@ -195,12 +195,12 @@ fun SumUpLibraryScreen(
         return
     }
     LazyColumn(
+        contentPadding = PaddingValues(top = 10.dp, bottom = 130.dp),
         modifier = Modifier
             .fillMaxSize()
             .padding(padding)
             .background(Color(0xFF0E0E13))
     ) {
-        item { Spacer(modifier = Modifier.height(10.dp)) }
         // Listening history & stats entry.
         item {
             Row(
@@ -291,7 +291,6 @@ fun SumUpLibraryScreen(
                 }
             }
         }
-        item { Spacer(modifier = Modifier.height(130.dp)) }
     }
 }
 

--- a/app/src/main/java/com/music/spotui/ui/screens/LikedSongsScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/LikedSongsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -66,7 +67,6 @@ import com.music.spotui.ui.theme.AppBackground
 import com.music.spotui.ui.theme.AppPalette
 import com.music.spotui.ui.viewmodel.LikedSongsViewModel
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun LikedSongsScreen(navController: NavController) {
@@ -114,6 +114,7 @@ fun LikedSongsScreen(navController: NavController) {
         }
 
         Scaffold(
+            containerColor = Color.Transparent,
             topBar = {
                 CenterAlignedTopAppBar(
                     modifier = Modifier.padding(16.dp, 0.dp),
@@ -135,11 +136,13 @@ fun LikedSongsScreen(navController: NavController) {
                     title = { Text(text = "") }
                 )
             }
-        ) {
+        ) { innerPadding ->
             LazyColumn(
+                contentPadding = innerPadding,
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color(AppBackground.toArgb()))
+                    .consumeWindowInsets(innerPadding)
             ) {
                 item {
                     Column(

--- a/app/src/main/java/com/music/spotui/ui/screens/LyricsScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/LyricsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -101,6 +102,7 @@ fun LyricsScreen(
                 )
             )
             .statusBarsPadding()
+            .navigationBarsPadding()
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/music/spotui/ui/screens/PlayerScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/PlayerScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.width
@@ -1102,6 +1103,7 @@ fun PlayerOptionsSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
+                .imePadding()
                 .padding(bottom = 12.dp)
         ) {
             if (showAlternativeStream) {

--- a/app/src/main/java/com/music/spotui/ui/screens/PlaylistScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/PlaylistScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -68,7 +69,6 @@ import com.music.spotui.ui.theme.AppBackground
 import com.music.spotui.ui.theme.AppPalette
 import com.music.spotui.ui.viewmodel.PlaylistViewModel
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun PlaylistScreen(navController: NavController, playlistId: String, playlistName: String = "") {
@@ -124,6 +124,7 @@ fun PlaylistScreen(navController: NavController, playlistId: String, playlistNam
         }
 
         Scaffold(
+            containerColor = Color.Transparent,
             topBar = {
                 CenterAlignedTopAppBar(
                     modifier = Modifier.padding(16.dp, 0.dp),
@@ -145,11 +146,13 @@ fun PlaylistScreen(navController: NavController, playlistId: String, playlistNam
                     title = { Text(text = "") }
                 )
             }
-        ) {
+        ) { innerPadding ->
             LazyColumn(
+                contentPadding = innerPadding,
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color(AppBackground.toArgb()))
+                    .consumeWindowInsets(innerPadding)
             ) {
                 item {
                     Column(

--- a/app/src/main/java/com/music/spotui/ui/screens/QueueScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/QueueScreen.kt
@@ -106,7 +106,12 @@ fun QueueScreen(navController: NavController) {
             Text("Queue", color = Color.White, fontSize = 18.sp, fontWeight = FontWeight.Bold)
         }
 
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 32.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding()
+        ) {
             current?.let {
                 item {
                     Text(
@@ -116,7 +121,7 @@ fun QueueScreen(navController: NavController) {
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.padding(16.dp, 12.dp, 16.dp, 6.dp)
                     )
-                    QueueRow(song = it, highlight = true, onClick = {})
+                    QueueRow(song = it, highlight = true, onClick = {}, isDragging = false, dragOffsetY = 0f)
                 }
             }
             if (upcoming.isNotEmpty()) {
@@ -149,52 +154,39 @@ fun QueueScreen(navController: NavController) {
                                     .background(Color(0xFF7A1F1F))
                                     .padding(horizontal = 24.dp),
                             ) {
-                                Icon(Icons.Default.Delete, contentDescription = "Remove", tint = Color.White)
+                                Icon(Icons.Default.Delete, contentDescription = "Delete", tint = Color.White)
                             }
                         },
-                        modifier = Modifier.graphicsLayer {
-                            translationY = if (isDragging) dragOffset else 0f
-                        },
-                    ) {
-                        QueueRow(
-                            song = song,
-                            highlight = false,
-                            onClick = {
-                                val idx = queue.indexOfFirst { it.id == song.id }
-                                playerViewModel.updateSongState(
-                                    song.coverUri, song.title, song.singer, true,
-                                    song.id, idx.coerceAtLeast(0), playerViewModel.currentSongAlbum.value
-                                )
-                                SongPlayer.playSong(song.url, context)
-                                navController.navigateUp()
-                            },
-                            dragHandle = Modifier.pointerInput(song.id) {
-                                detectDragGestures(
-                                    onDragStart = {
-                                        draggingId = song.id
-                                        dragOffset = 0f
-                                    },
-                                    onDragEnd = { draggingId = -1; dragOffset = 0f },
-                                    onDragCancel = { draggingId = -1; dragOffset = 0f },
-                                ) { change, dragAmount ->
-                                    change.consume()
-                                    dragOffset += dragAmount.y
-                                    // Crossed a full row height → swap with the neighbour.
+                        content = {
+                            QueueRow(
+                                song = song,
+                                highlight = false,
+                                isDragging = isDragging,
+                                dragOffsetY = if (isDragging) dragOffset else 0f,
+                                onClick = {
                                     val abs = queue.indexOfFirst { it.id == song.id }
-                                    if (dragOffset > rowHeightPx / 2 && upIdx < upcoming.size - 1) {
-                                        playerViewModel.moveQueueItem(abs, abs + 1)
-                                        dragOffset -= rowHeightPx
-                                    } else if (dragOffset < -rowHeightPx / 2 && upIdx > 0) {
-                                        playerViewModel.moveQueueItem(abs, abs - 1)
-                                        dragOffset += rowHeightPx
+                                    if (abs >= 0) playerViewModel.playSongAt(queue, abs, context)
+                                },
+                                onDragStart = { draggingId = song.id; dragOffset = 0f },
+                                onDragEnd = { draggingId = -1; dragOffset = 0f },
+                                onDragDelta = { dy ->
+                                    dragOffset += dy
+                                    val abs = queue.indexOfFirst { it.id == song.id }
+                                    if (abs >= 0) {
+                                        if (dragOffset > rowHeightPx / 2 && abs < queue.size - 1) {
+                                            playerViewModel.moveQueueItem(abs, abs + 1)
+                                            dragOffset -= rowHeightPx
+                                        } else if (dragOffset < -rowHeightPx / 2 && upIdx > 0) {
+                                            playerViewModel.moveQueueItem(abs, abs - 1)
+                                            dragOffset += rowHeightPx
+                                        }
                                     }
-                                }
-                            },
-                        )
-                    }
+                                },
+                            )
+                        }
+                    )
                 }
             }
-            item { Spacer(modifier = Modifier.height(120.dp)) }
         }
     }
 }

--- a/app/src/main/java/com/music/spotui/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/SearchScreen.kt
@@ -133,6 +133,7 @@ fun SumUpSearchScreen(
     }
 
     LazyColumn(
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 130.dp),
         modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))
@@ -289,10 +290,6 @@ fun SumUpSearchScreen(
                     })
                 }
             }
-        }
-
-        item{
-            Spacer(modifier = Modifier.height(130.dp))
         }
 
     }

--- a/app/src/main/java/com/music/spotui/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -59,7 +60,6 @@ import com.music.spotui.data.preferences.setWifiQuality
 import com.music.spotui.ui.theme.AppBackground
 import com.music.spotui.ui.theme.AppPalette
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(navController: NavController) {
@@ -94,12 +94,10 @@ fun SettingsScreen(navController: NavController) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 72.dp)
+                .padding(padding)
+                .consumeWindowInsets(padding)
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp)
-                // Clear the bottom nav + mini player so the last section
-                // (crossfade / DJ mixing) isn't hidden under the bar.
-                .padding(bottom = 160.dp)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
             SectionTitle("Audio quality")
             QualityPicker(

--- a/app/src/main/java/com/music/spotui/ui/screens/ShowScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/ShowScreen.kt
@@ -59,6 +59,7 @@ fun ShowScreen(navController: NavController, showId: String, showName: String = 
     val episodes = (episodesState as? Response.Success)?.data.orEmpty()
 
     LazyColumn(
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 130.dp),
         modifier = Modifier
             .fillMaxSize()
             .background(Color(AppBackground.toArgb()))

--- a/app/src/main/java/com/music/spotui/ui/screens/SpotifyLoginScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/SpotifyLoginScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -199,6 +201,8 @@ private fun LoginForm(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .safeDrawingPadding()
+            .imePadding()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 28.dp),
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
### Description
This PR standardizes window insets, status bar/navigation bar paddings, and scaffold content paddings across all UI screens to ensure a consistent edge-to-edge experience throughout the app.

### Key Changes
- **Window Inset & Activity Setup**: Updated `MainActivity` and `App` for consistent system bar inset handling.
- **Screen Layouts**: Unified Scaffold `contentPadding`, `WindowInsets.statusBars`, and `WindowInsets.navigationBars` handling across `QueueScreen`, `AlbumScreen`, `ArtistScreen`, `DownloadsScreen`, `HomeScreen`, `LibraryScreen`, `LikedSongsScreen`, `LyricsScreen`, `PlayerScreen`, `PlaylistScreen`, `SearchScreen`, `SettingsScreen`, `ShowScreen`, and `SpotifyLoginScreen`.
- **Navigation & Components**: Adjusted `MainBottomNavigation`, `LikedSongsAlbum`, and `SavedInSheet` to respect system insets cleanly without unwanted overlaps.