### PR TITLE
fix: use white status bar icons for better contrast

### DIFF
--- a/app/src/main/java/com/music/spotui/ui/theme/Theme.kt
+++ b/app/src/main/java/com/music/spotui/ui/theme/Theme.kt
@@ -62,7 +62,7 @@ fun SpotuiTheme(
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = Color.Transparent.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = false
         }
     }
 


### PR DESCRIPTION
Icons in the status bar were dark against the app background. Make them white for better contrast.