### PR TITLE
Fix offline cold-start: persist Library + Home feed cache, fix broken gradle wrapper

### DIFF
--- a/app/src/main/java/com/music/spotui/data/api/Api.kt
+++ b/app/src/main/java/com/music/spotui/data/api/Api.kt
@@ -157,9 +157,18 @@ class Api @Inject constructor(
      * etc. Process-cached like the other home feeds for instant re-entry.
      */
     suspend fun getHomeFeed(): Flow<Response<HomeFeedModel>> = flow {
-        HomeCache.home?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
+        val diskHome = HomeCache.home
+            ?: com.music.spotui.data.preferences.loadHomeFeedCache(context)?.also { HomeCache.home = it }
+        diskHome?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
         if (!SpotifyTokenProvider.ensureToken(context)) {
-            if (HomeCache.home == null) emit(Response.Error("Spotify not authenticated — set sp_dc cookie"))
+            if (diskHome == null) {
+                // No cache at all and no connection: show an empty (but
+                // successful) feed instead of a hard error banner blocking
+                // the whole Home tab — Library/Downloads are still usable.
+                val empty = HomeFeedModel()
+                HomeCache.home = empty
+                emit(Response.Success(empty))
+            }
             return@flow
         }
         Spotify.home(sectionItemsLimit = 20).fold(
@@ -177,6 +186,7 @@ class Api @Inject constructor(
                 }.distinctBy { it.title.lowercase().ifBlank { it.hashCode().toString() } }
                 val model = HomeFeedModel(greeting = feed.greeting ?: "", sections = sections)
                 HomeCache.home = model
+                com.music.spotui.data.preferences.saveHomeFeedCache(context, model)
                 emit(Response.Success(model))
             },
             onFailure = {
@@ -574,9 +584,35 @@ class Api @Inject constructor(
      * GQL endpoint (not rate-limited). Process-cached for instant re-entry.
      */
     suspend fun getLibrary(): Flow<Response<List<com.music.spotui.data.entity.LibraryEntry>>> = flow {
-        HomeCache.library?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
+        // Fall back to the on-disk cache (survives process death) when there's
+        // nothing in memory yet, e.g. a cold start with no internet.
+        val diskCache = HomeCache.library
+            ?: com.music.spotui.data.preferences.loadLibraryCache(context)?.also { HomeCache.library = it }
+        diskCache?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
         if (!SpotifyTokenProvider.ensureToken(context)) {
-            if (HomeCache.library == null) emit(Response.Error("Spotify not authenticated — set sp_dc cookie"))
+            if (diskCache == null) {
+                // First ever launch with no connection: still surface the local
+                // shortcuts (Liked Songs / Downloaded) instead of a hard error,
+                // so offline downloads remain reachable without any network call.
+                val offline = listOf(
+                    com.music.spotui.data.entity.LibraryEntry(
+                        spotifyId = LIKED_SONGS_ID,
+                        name = "Liked Songs",
+                        subtitle = "Playlist • Liked songs",
+                        coverUri = "https://misc.scdn.co/liked-songs/liked-songs-640.png",
+                        isPlaylist = true,
+                    ),
+                    com.music.spotui.data.entity.LibraryEntry(
+                        spotifyId = DOWNLOADS_ID,
+                        name = "Downloaded",
+                        subtitle = "Available offline",
+                        coverUri = "",
+                        isPlaylist = true,
+                    ),
+                )
+                HomeCache.library = offline
+                emit(Response.Success(offline))
+            }
             return@flow
         }
         val albums = fetchAllPages { offset -> Spotify.myAlbums(limit = 50, offset = offset) }.map { a ->
@@ -616,6 +652,7 @@ class Api @Inject constructor(
         )
         val merged = listOf(liked, downloaded) + playlists + albums
         HomeCache.library = merged
+        com.music.spotui.data.preferences.saveLibraryCache(context, merged)
         emit(Response.Success(merged))
     }
 

--- a/app/src/main/java/com/music/spotui/data/preferences/LibraryCachePref.kt
+++ b/app/src/main/java/com/music/spotui/data/preferences/LibraryCachePref.kt
@@ -1,0 +1,120 @@
+package com.music.spotui.data.preferences
+
+import android.content.Context
+import com.music.spotui.data.entity.LibraryEntry
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Persists the last successfully fetched "Your Library" list to disk (not just
+ * in-memory [com.music.spotui.data.api.Api.HomeCache]) so that a cold app start
+ * with no internet connection still has something to show instead of an empty /
+ * error screen. Overwritten every time [getLibrary] succeeds online.
+ */
+private const val PREF = "LibraryCache"
+private const val KEY = "entries"
+
+private fun LibraryEntry.toJson(): JSONObject = JSONObject().apply {
+    put("spotifyId", spotifyId)
+    put("name", name)
+    put("subtitle", subtitle)
+    put("coverUri", coverUri)
+    put("isPlaylist", isPlaylist)
+    put("artists", artists)
+}
+
+private fun parseEntry(o: JSONObject): LibraryEntry = LibraryEntry(
+    spotifyId = o.getString("spotifyId"),
+    name = o.getString("name"),
+    subtitle = o.optString("subtitle"),
+    coverUri = o.optString("coverUri"),
+    isPlaylist = o.optBoolean("isPlaylist", false),
+    artists = o.optString("artists"),
+)
+
+fun saveLibraryCache(context: Context, entries: List<LibraryEntry>) {
+    val arr = JSONArray()
+    entries.forEach { arr.put(it.toJson()) }
+    context.getSharedPreferences(PREF, Context.MODE_PRIVATE).edit()
+        .putString(KEY, arr.toString())
+        .apply()
+}
+
+fun loadLibraryCache(context: Context): List<LibraryEntry>? {
+    val json = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        .getString(KEY, null) ?: return null
+    return runCatching {
+        val arr = JSONArray(json)
+        (0 until arr.length()).map { parseEntry(arr.getJSONObject(it)) }
+    }.getOrNull()
+}
+
+// ---------------------------------------------------------------------------
+// Home feed cache — same idea, for the Home/Discover tab (getHomeFeed()),
+// which previously also only cached in memory and errored out on a cold
+// offline start even if it had loaded fine minutes earlier.
+// ---------------------------------------------------------------------------
+
+private const val HOME_PREF = "HomeFeedCache"
+private const val HOME_KEY = "feed"
+
+private fun com.music.spotui.data.entity.HomeItem.toJson(): JSONObject = JSONObject().apply {
+    when (val item = this@toJson) {
+        is com.music.spotui.data.entity.HomeItem.Album -> {
+            put("type", "album"); put("name", item.name); put("imageUrl", item.imageUrl)
+            put("subtitle", item.subtitle); put("artists", item.artists)
+        }
+        is com.music.spotui.data.entity.HomeItem.Artist -> {
+            put("type", "artist"); put("name", item.name); put("imageUrl", item.imageUrl)
+            put("id", item.id)
+        }
+        is com.music.spotui.data.entity.HomeItem.Playlist -> {
+            put("type", "playlist"); put("name", item.name); put("imageUrl", item.imageUrl)
+            put("subtitle", item.subtitle); put("id", item.id)
+        }
+    }
+}
+
+private fun parseHomeItem(o: JSONObject): com.music.spotui.data.entity.HomeItem? = when (o.optString("type")) {
+    "album" -> com.music.spotui.data.entity.HomeItem.Album(
+        name = o.getString("name"), imageUrl = o.optString("imageUrl"),
+        subtitle = o.optString("subtitle"), artists = o.optString("artists"),
+    )
+    "artist" -> com.music.spotui.data.entity.HomeItem.Artist(
+        name = o.getString("name"), imageUrl = o.optString("imageUrl"), id = o.optString("id"),
+    )
+    "playlist" -> com.music.spotui.data.entity.HomeItem.Playlist(
+        name = o.getString("name"), imageUrl = o.optString("imageUrl"),
+        subtitle = o.optString("subtitle"), id = o.optString("id"),
+    )
+    else -> null
+}
+
+fun saveHomeFeedCache(context: Context, feed: com.music.spotui.data.entity.HomeFeedModel) {
+    val sections = JSONArray()
+    feed.sections.forEach { section ->
+        val items = JSONArray()
+        section.items.forEach { items.put(it.toJson()) }
+        sections.put(JSONObject().apply { put("title", section.title); put("items", items) })
+    }
+    val root = JSONObject().apply { put("greeting", feed.greeting); put("sections", sections) }
+    context.getSharedPreferences(HOME_PREF, Context.MODE_PRIVATE).edit()
+        .putString(HOME_KEY, root.toString())
+        .apply()
+}
+
+fun loadHomeFeedCache(context: Context): com.music.spotui.data.entity.HomeFeedModel? {
+    val json = context.getSharedPreferences(HOME_PREF, Context.MODE_PRIVATE)
+        .getString(HOME_KEY, null) ?: return null
+    return runCatching {
+        val root = JSONObject(json)
+        val sectionsArr = root.getJSONArray("sections")
+        val sections = (0 until sectionsArr.length()).map { i ->
+            val s = sectionsArr.getJSONObject(i)
+            val itemsArr = s.getJSONArray("items")
+            val items = (0 until itemsArr.length()).mapNotNull { parseHomeItem(itemsArr.getJSONObject(it)) }
+            com.music.spotui.data.entity.HomeSection(title = s.getString("title"), items = items)
+        }
+        com.music.spotui.data.entity.HomeFeedModel(greeting = root.optString("greeting"), sections = sections)
+    }.getOrNull()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jan 19 21:18:24 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=file\:/private/tmp/claude-501/-Users-tim/dec97246-c452-466c-9311-39aba59bb862/scratchpad/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Problem
- `getLibrary()` and `getHomeFeed()` only cached responses in memory
  (`HomeCache`), which is wiped on every process restart. A cold app
  start with no internet connection always hit the `ensureToken()`
  failure path and, with no cache, emitted `Response.Error` — showing
  "Couldn't load your library" / "Couldn't load music" even though
  the same data had loaded fine minutes earlier, and even though
  downloaded (offline) tracks were still on disk and reachable.
- `gradle/wrapper/gradle-wrapper.properties` had a stale local
  `file:///private/tmp/...` distributionUrl instead of the real Gradle
  download URL, breaking `./gradlew` for anyone cloning the repo fresh.

## Fix
- Added `LibraryCachePref.kt`: a small SharedPreferences-backed JSON
  cache for both the Library list and the Home feed.
- `getLibrary()` / `getHomeFeed()` now fall back to this disk cache on
  a cold start before hitting the network, and persist every
  successful fetch to it.
- If there's truly no cache yet and no connection, they no longer
  emit `Response.Error`: Library falls back to the pinned "Liked
  Songs" / "Downloaded" shortcuts (so offline downloads stay
  reachable with zero network calls), and Home falls back to an empty
  feed instead of a blocking error banner.
- Fixed the wrapper's `distributionUrl` to point at the real Gradle
  8.6 binary.

## Testing
Built and installed a debug APK, logged in, downloaded a track,
force-killed the app, disabled all connectivity, and relaunched:
Library and Home now show the last cached content instead of an
error, and the downloaded track is reachable via the pinned
"Downloaded" shortcut.