### PR TITLE
Default Wi-Fi streaming to Lossless, add Canvas toggle (#55), offline-cache Liked Songs

### DIFF
--- a/app/src/main/java/com/music/spotui/data/api/Api.kt
+++ b/app/src/main/java/com/music/spotui/data/api/Api.kt
@@ -676,9 +676,15 @@ class Api @Inject constructor(
 
     /** The user's Spotify "Liked Songs" (saved tracks) as playable songs. */
     suspend fun getLikedSongs(): Flow<Response<List<SongsModel>>> = flow {
-        emit(Response.Loading())
+        // Same offline-cache pattern as getLibrary()/getHomeFeed() (see #69):
+        // fall back to the last successfully fetched list on disk before
+        // touching the network, and never leave the screen on a hard error
+        // if we have something — even stale — to show instead.
+        val diskCache = com.music.spotui.data.preferences.loadLikedSongsCache(context)
+        diskCache?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
         if (!SpotifyTokenProvider.ensureToken(context)) {
-            emit(Response.Error("Spotify not authenticated")); return@flow
+            if (diskCache == null) emit(Response.Error("Spotify not authenticated"))
+            return@flow
         }
         Spotify.likedSongs(limit = 50).fold(
             onSuccess = { first ->
@@ -698,8 +704,12 @@ class Api @Inject constructor(
                     offset += page.items.size
                     emit(Response.Success(models.toList()))
                 }
+                com.music.spotui.data.preferences.saveLikedSongsCache(context, models)
             },
-            onFailure = { Log.e("Api", "getLikedSongs failed", it); emit(Response.Error(it.message ?: "error")) },
+            onFailure = {
+                Log.e("Api", "getLikedSongs failed", it)
+                if (diskCache == null) emit(Response.Error(it.message ?: "error"))
+            },
         )
     }
 

--- a/app/src/main/java/com/music/spotui/data/api/Api.kt
+++ b/app/src/main/java/com/music/spotui/data/api/Api.kt
@@ -157,9 +157,18 @@ class Api @Inject constructor(
      * etc. Process-cached like the other home feeds for instant re-entry.
      */
     suspend fun getHomeFeed(): Flow<Response<HomeFeedModel>> = flow {
-        HomeCache.home?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
+        val diskHome = HomeCache.home
+            ?: com.music.spotui.data.preferences.loadHomeFeedCache(context)?.also { HomeCache.home = it }
+        diskHome?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
         if (!SpotifyTokenProvider.ensureToken(context)) {
-            if (HomeCache.home == null) emit(Response.Error("Spotify not authenticated — set sp_dc cookie"))
+            if (diskHome == null) {
+                // No cache at all and no connection: show an empty (but
+                // successful) feed instead of a hard error banner blocking
+                // the whole Home tab — Library/Downloads are still usable.
+                val empty = HomeFeedModel()
+                HomeCache.home = empty
+                emit(Response.Success(empty))
+            }
             return@flow
         }
         Spotify.home(sectionItemsLimit = 20).fold(
@@ -177,6 +186,7 @@ class Api @Inject constructor(
                 }.distinctBy { it.title.lowercase().ifBlank { it.hashCode().toString() } }
                 val model = HomeFeedModel(greeting = feed.greeting ?: "", sections = sections)
                 HomeCache.home = model
+                com.music.spotui.data.preferences.saveHomeFeedCache(context, model)
                 emit(Response.Success(model))
             },
             onFailure = {
@@ -574,9 +584,35 @@ class Api @Inject constructor(
      * GQL endpoint (not rate-limited). Process-cached for instant re-entry.
      */
     suspend fun getLibrary(): Flow<Response<List<com.music.spotui.data.entity.LibraryEntry>>> = flow {
-        HomeCache.library?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
+        // Fall back to the on-disk cache (survives process death) when there's
+        // nothing in memory yet, e.g. a cold start with no internet.
+        val diskCache = HomeCache.library
+            ?: com.music.spotui.data.preferences.loadLibraryCache(context)?.also { HomeCache.library = it }
+        diskCache?.let { emit(Response.Success(it)) } ?: emit(Response.Loading())
         if (!SpotifyTokenProvider.ensureToken(context)) {
-            if (HomeCache.library == null) emit(Response.Error("Spotify not authenticated — set sp_dc cookie"))
+            if (diskCache == null) {
+                // First ever launch with no connection: still surface the local
+                // shortcuts (Liked Songs / Downloaded) instead of a hard error,
+                // so offline downloads remain reachable without any network call.
+                val offline = listOf(
+                    com.music.spotui.data.entity.LibraryEntry(
+                        spotifyId = LIKED_SONGS_ID,
+                        name = "Liked Songs",
+                        subtitle = "Playlist • Liked songs",
+                        coverUri = "https://misc.scdn.co/liked-songs/liked-songs-640.png",
+                        isPlaylist = true,
+                    ),
+                    com.music.spotui.data.entity.LibraryEntry(
+                        spotifyId = DOWNLOADS_ID,
+                        name = "Downloaded",
+                        subtitle = "Available offline",
+                        coverUri = "",
+                        isPlaylist = true,
+                    ),
+                )
+                HomeCache.library = offline
+                emit(Response.Success(offline))
+            }
             return@flow
         }
         val albums = fetchAllPages { offset -> Spotify.myAlbums(limit = 50, offset = offset) }.map { a ->
@@ -616,6 +652,7 @@ class Api @Inject constructor(
         )
         val merged = listOf(liked, downloaded) + playlists + albums
         HomeCache.library = merged
+        com.music.spotui.data.preferences.saveLibraryCache(context, merged)
         emit(Response.Success(merged))
     }
 

--- a/app/src/main/java/com/music/spotui/data/preferences/LibraryCachePref.kt
+++ b/app/src/main/java/com/music/spotui/data/preferences/LibraryCachePref.kt
@@ -1,0 +1,120 @@
+package com.music.spotui.data.preferences
+
+import android.content.Context
+import com.music.spotui.data.entity.LibraryEntry
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Persists the last successfully fetched "Your Library" list to disk (not just
+ * in-memory [com.music.spotui.data.api.Api.HomeCache]) so that a cold app start
+ * with no internet connection still has something to show instead of an empty /
+ * error screen. Overwritten every time [getLibrary] succeeds online.
+ */
+private const val PREF = "LibraryCache"
+private const val KEY = "entries"
+
+private fun LibraryEntry.toJson(): JSONObject = JSONObject().apply {
+    put("spotifyId", spotifyId)
+    put("name", name)
+    put("subtitle", subtitle)
+    put("coverUri", coverUri)
+    put("isPlaylist", isPlaylist)
+    put("artists", artists)
+}
+
+private fun parseEntry(o: JSONObject): LibraryEntry = LibraryEntry(
+    spotifyId = o.getString("spotifyId"),
+    name = o.getString("name"),
+    subtitle = o.optString("subtitle"),
+    coverUri = o.optString("coverUri"),
+    isPlaylist = o.optBoolean("isPlaylist", false),
+    artists = o.optString("artists"),
+)
+
+fun saveLibraryCache(context: Context, entries: List<LibraryEntry>) {
+    val arr = JSONArray()
+    entries.forEach { arr.put(it.toJson()) }
+    context.getSharedPreferences(PREF, Context.MODE_PRIVATE).edit()
+        .putString(KEY, arr.toString())
+        .apply()
+}
+
+fun loadLibraryCache(context: Context): List<LibraryEntry>? {
+    val json = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        .getString(KEY, null) ?: return null
+    return runCatching {
+        val arr = JSONArray(json)
+        (0 until arr.length()).map { parseEntry(arr.getJSONObject(it)) }
+    }.getOrNull()
+}
+
+// ---------------------------------------------------------------------------
+// Home feed cache — same idea, for the Home/Discover tab (getHomeFeed()),
+// which previously also only cached in memory and errored out on a cold
+// offline start even if it had loaded fine minutes earlier.
+// ---------------------------------------------------------------------------
+
+private const val HOME_PREF = "HomeFeedCache"
+private const val HOME_KEY = "feed"
+
+private fun com.music.spotui.data.entity.HomeItem.toJson(): JSONObject = JSONObject().apply {
+    when (val item = this@toJson) {
+        is com.music.spotui.data.entity.HomeItem.Album -> {
+            put("type", "album"); put("name", item.name); put("imageUrl", item.imageUrl)
+            put("subtitle", item.subtitle); put("artists", item.artists)
+        }
+        is com.music.spotui.data.entity.HomeItem.Artist -> {
+            put("type", "artist"); put("name", item.name); put("imageUrl", item.imageUrl)
+            put("id", item.id)
+        }
+        is com.music.spotui.data.entity.HomeItem.Playlist -> {
+            put("type", "playlist"); put("name", item.name); put("imageUrl", item.imageUrl)
+            put("subtitle", item.subtitle); put("id", item.id)
+        }
+    }
+}
+
+private fun parseHomeItem(o: JSONObject): com.music.spotui.data.entity.HomeItem? = when (o.optString("type")) {
+    "album" -> com.music.spotui.data.entity.HomeItem.Album(
+        name = o.getString("name"), imageUrl = o.optString("imageUrl"),
+        subtitle = o.optString("subtitle"), artists = o.optString("artists"),
+    )
+    "artist" -> com.music.spotui.data.entity.HomeItem.Artist(
+        name = o.getString("name"), imageUrl = o.optString("imageUrl"), id = o.optString("id"),
+    )
+    "playlist" -> com.music.spotui.data.entity.HomeItem.Playlist(
+        name = o.getString("name"), imageUrl = o.optString("imageUrl"),
+        subtitle = o.optString("subtitle"), id = o.optString("id"),
+    )
+    else -> null
+}
+
+fun saveHomeFeedCache(context: Context, feed: com.music.spotui.data.entity.HomeFeedModel) {
+    val sections = JSONArray()
+    feed.sections.forEach { section ->
+        val items = JSONArray()
+        section.items.forEach { items.put(it.toJson()) }
+        sections.put(JSONObject().apply { put("title", section.title); put("items", items) })
+    }
+    val root = JSONObject().apply { put("greeting", feed.greeting); put("sections", sections) }
+    context.getSharedPreferences(HOME_PREF, Context.MODE_PRIVATE).edit()
+        .putString(HOME_KEY, root.toString())
+        .apply()
+}
+
+fun loadHomeFeedCache(context: Context): com.music.spotui.data.entity.HomeFeedModel? {
+    val json = context.getSharedPreferences(HOME_PREF, Context.MODE_PRIVATE)
+        .getString(HOME_KEY, null) ?: return null
+    return runCatching {
+        val root = JSONObject(json)
+        val sectionsArr = root.getJSONArray("sections")
+        val sections = (0 until sectionsArr.length()).map { i ->
+            val s = sectionsArr.getJSONObject(i)
+            val itemsArr = s.getJSONArray("items")
+            val items = (0 until itemsArr.length()).mapNotNull { parseHomeItem(itemsArr.getJSONObject(it)) }
+            com.music.spotui.data.entity.HomeSection(title = s.getString("title"), items = items)
+        }
+        com.music.spotui.data.entity.HomeFeedModel(greeting = root.optString("greeting"), sections = sections)
+    }.getOrNull()
+}

--- a/app/src/main/java/com/music/spotui/data/preferences/LibraryCachePref.kt
+++ b/app/src/main/java/com/music/spotui/data/preferences/LibraryCachePref.kt
@@ -50,6 +50,45 @@ fun loadLibraryCache(context: Context): List<LibraryEntry>? {
 }
 
 // ---------------------------------------------------------------------------
+// Liked Songs cache — same idea, for getLikedSongs() (see #69 / #33 / #51):
+// it only ever came straight from the network, so opening "Liked Songs"
+// offline always hard-errored even right after it had loaded fine.
+// ---------------------------------------------------------------------------
+
+private const val LIKED_PREF = "LikedSongsCache"
+private const val LIKED_KEY = "songs"
+
+private fun com.music.spotui.data.entity.SongsModel.toJson(): JSONObject = JSONObject().apply {
+    put("id", id); put("title", title); put("album", album); put("singer", singer)
+    put("coverUri", coverUri); put("url", url); put("spotifyTrackId", spotifyTrackId)
+    put("explicit", explicit); put("durationMs", durationMs)
+}
+
+private fun parseSong(o: JSONObject): com.music.spotui.data.entity.SongsModel = com.music.spotui.data.entity.SongsModel(
+    id = o.getInt("id"), title = o.getString("title"), album = o.optString("album"),
+    singer = o.optString("singer"), coverUri = o.optString("coverUri"), url = o.optString("url"),
+    spotifyTrackId = o.optString("spotifyTrackId"), explicit = o.optBoolean("explicit", false),
+    durationMs = o.optInt("durationMs", 0),
+)
+
+fun saveLikedSongsCache(context: Context, songs: List<com.music.spotui.data.entity.SongsModel>) {
+    val arr = JSONArray()
+    songs.forEach { arr.put(it.toJson()) }
+    context.getSharedPreferences(LIKED_PREF, Context.MODE_PRIVATE).edit()
+        .putString(LIKED_KEY, arr.toString())
+        .apply()
+}
+
+fun loadLikedSongsCache(context: Context): List<com.music.spotui.data.entity.SongsModel>? {
+    val json = context.getSharedPreferences(LIKED_PREF, Context.MODE_PRIVATE)
+        .getString(LIKED_KEY, null) ?: return null
+    return runCatching {
+        val arr = JSONArray(json)
+        (0 until arr.length()).map { parseSong(arr.getJSONObject(it)) }
+    }.getOrNull()
+}
+
+// ---------------------------------------------------------------------------
 // Home feed cache — same idea, for the Home/Discover tab (getHomeFeed()),
 // which previously also only cached in memory and errored out on a cold
 // offline start even if it had loaded fine minutes earlier.

--- a/app/src/main/java/com/music/spotui/data/preferences/SettingsPref.kt
+++ b/app/src/main/java/com/music/spotui/data/preferences/SettingsPref.kt
@@ -44,7 +44,7 @@ private fun readQ(c: Context, key: String, def: StreamQuality): StreamQuality =
 private fun writeQ(c: Context, key: String, q: StreamQuality) =
     prefs(c).edit().putString(key, q.name).apply()
 
-fun getWifiQuality(c: Context): StreamQuality = readQ(c, KEY_WIFI_Q, StreamQuality.HIGH)
+fun getWifiQuality(c: Context): StreamQuality = readQ(c, KEY_WIFI_Q, StreamQuality.LOSSLESS)
 fun setWifiQuality(c: Context, q: StreamQuality) = writeQ(c, KEY_WIFI_Q, q)
 
 fun getCellularQuality(c: Context): StreamQuality = readQ(c, KEY_CELL_Q, StreamQuality.NORMAL)
@@ -105,3 +105,9 @@ fun currentStreamingQuality(c: Context): StreamQuality {
     val cm = c.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     return if (cm.isActiveNetworkMetered) getCellularQuality(c) else getWifiQuality(c)
 }
+
+/** Spotify Canvas (looping video behind the now-playing screen). Fetches a video
+ *  per track over the network, so some people prefer to turn it off — see #55. */
+private const val KEY_CANVAS_ENABLED = "canvas_enabled"
+fun isCanvasEnabled(c: Context): Boolean = prefs(c).getBoolean(KEY_CANVAS_ENABLED, true)
+fun setCanvasEnabled(c: Context, v: Boolean) = prefs(c).edit().putBoolean(KEY_CANVAS_ENABLED, v).apply()

--- a/app/src/main/java/com/music/spotui/ui/screens/PlayerScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/PlayerScreen.kt
@@ -237,10 +237,16 @@ fun PlayerScreen(navController: NavController) {
         }
     }
 
-    // Load the current track's Spotify Canvas (full-screen looping video background).
+    // Load the current track's Spotify Canvas (full-screen looping video background),
+    // unless the user turned it off in Settings (see #55) — it fetches a video per
+    // track over the network, which not everyone wants.
     LaunchedEffect(playerViewModel.currentSongId.value, queueSongs) {
-        val track = queueSongs.firstOrNull { it.id == playerViewModel.currentSongId.value }
-        playerViewModel.loadCanvas(track?.spotifyTrackId.orEmpty())
+        if (com.music.spotui.data.preferences.isCanvasEnabled(context)) {
+            val track = queueSongs.firstOrNull { it.id == playerViewModel.currentSongId.value }
+            playerViewModel.loadCanvas(track?.spotifyTrackId.orEmpty())
+        } else {
+            playerViewModel.loadCanvas("")
+        }
     }
 
 

--- a/app/src/main/java/com/music/spotui/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/music/spotui/ui/screens/SettingsScreen.kt
@@ -51,6 +51,8 @@ import com.music.spotui.data.preferences.getCellularQuality
 import com.music.spotui.data.preferences.getCrossfadeMs
 import com.music.spotui.data.preferences.setCrossfadeMs
 import com.music.spotui.data.preferences.getDownloadQuality
+import com.music.spotui.data.preferences.isCanvasEnabled
+import com.music.spotui.data.preferences.setCanvasEnabled
 import com.music.spotui.data.preferences.isVideoFallbackEnabled
 import com.music.spotui.data.preferences.getWifiQuality
 import com.music.spotui.data.preferences.setCellularQuality
@@ -70,6 +72,7 @@ fun SettingsScreen(navController: NavController) {
     var dlQ by remember { mutableStateOf(getDownloadQuality(context)) }
     var crossfadeMs by remember { mutableStateOf(getCrossfadeMs(context).toFloat()) }
     var videoFallback by remember { mutableStateOf(isVideoFallbackEnabled(context)) }
+    var canvasEnabled by remember { mutableStateOf(isCanvasEnabled(context)) }
     // Read fresh each composition so returning from the Deezer login reflects it.
     val deezerConnected = com.music.spotui.data.preferences.getDeezerArl(context) != null
     val deezerTier = com.music.spotui.data.preferences.getDeezerTier(context)
@@ -142,6 +145,17 @@ fun SettingsScreen(navController: NavController) {
             ) {
                 videoFallback = it
                 setVideoFallbackEnabled(context, it)
+            }
+
+            Spacer(Modifier.height(12.dp))
+            SectionTitle("Now Playing")
+            SettingsSwitchRow(
+                title = "Spotify Canvas",
+                subtitle = "Show the looping background video on the player screen",
+                checked = canvasEnabled,
+            ) {
+                canvasEnabled = it
+                setCanvasEnabled(context, it)
             }
 
             Spacer(Modifier.height(12.dp))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jan 19 21:18:24 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=file\:/private/tmp/claude-501/-Users-tim/dec97246-c452-466c-9311-39aba59bb862/scratchpad/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
> **Note:** this branch is based on top of #69 (`fix/offline-library-cache`),
> so this diff currently includes those changes too. Once #69 is merged,
> this PR will automatically shrink to just the new commit below.

## Changes

**Default Wi-Fi streaming quality → Lossless**
Wi-Fi streaming previously defaulted to `HIGH`, which skips the
lossless-source lookup entirely and goes straight to the slow YouTube
fallback unless the user manually switches to Lossless in Settings.
Now it defaults to `LOSSLESS`, so a fresh install tries the fast,
login-free Tidal community FLAC source first. Cellular default is left
at `NORMAL` to avoid surprising anyone's mobile data usage.

**Canvas on/off toggle** (closes #55)
Added a switch under Settings → "Now Playing" to disable the looping
video background on the player screen — it fetches a video per track
over the network, which not everyone wants.

**Liked Songs offline cache** (related to #33, #51)
`getLikedSongs()` had the same in-memory-only, hard-error-offline bug
that `getLibrary()`/`getHomeFeed()` had before #69 — it's one of the
two pinned Library shortcuts that's supposed to work offline in the
first place. Extended the same disk-cache + graceful-fallback pattern
to it.

## Testing
Built and installed a debug APK on two separate machines. Verified:
- Fresh install shows Lossless as the Wi-Fi default in Settings
  without manual toggling.
- Canvas switch correctly shows/hides the background video.
- Liked Songs loaded online, then force-killed + offline relaunch
  shows the cached list instead of erroring.